### PR TITLE
Drop `laminas/laminas-zendframework-bridge` and `zendframework/*` compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,7 @@
         "laminas/laminas-loader": "^2.7",
         "laminas/laminas-math": "^3.3",
         "laminas/laminas-stdlib": "^3.2",
-        "laminas/laminas-uri": "^2.8",
-        "laminas/laminas-zendframework-bridge": "^1.0"
+        "laminas/laminas-uri": "^2.8"
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~1.0.0",
@@ -46,7 +45,7 @@
     "scripts": {
         "static-analysis": "psalm --shepherd --stats"
     },
-    "replace": {
-        "zendframework/zendoauth": "^2.0.3"
+    "conflict": {
+        "zendframework/zendoauth": "*"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "06ffafd54766013d0df37293aff4651d",
+    "content-hash": "b65c6ccade48618206e26b89b4f43e08",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -728,24 +728,26 @@
         },
         {
             "name": "laminas/laminas-zendframework-bridge",
-            "version": "1.1.1",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-zendframework-bridge.git",
-                "reference": "6ede70583e101030bcace4dcddd648f760ddf642"
+                "reference": "bf180a382393e7db5c1e8d0f2ec0c4af9c724baf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/6ede70583e101030bcace4dcddd648f760ddf642",
-                "reference": "6ede70583e101030bcace4dcddd648f760ddf642",
+                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/bf180a382393e7db5c1e8d0f2ec0c4af9c724baf",
+                "reference": "bf180a382393e7db5c1e8d0f2ec0c4af9c724baf",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0 || ^8.0"
+                "php": "^7.3 || ~8.0.0 || ~8.1.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^8.1 || ^9.3",
-                "squizlabs/php_codesniffer": "^3.5"
+                "phpunit/phpunit": "^9.3",
+                "psalm/plugin-phpunit": "^0.15.1",
+                "squizlabs/php_codesniffer": "^3.5",
+                "vimeo/psalm": "^4.6"
             },
             "type": "library",
             "extra": {
@@ -784,7 +786,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2020-09-14T14:23:00+00:00"
+            "time": "2021-09-03T17:53:30+00:00"
         },
         {
             "name": "psr/container",
@@ -3062,5 +3064,5 @@
         "php": "^7.3 || ~8.0.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description


Increase performance by removing a compatibility layer while **not** introducing breaking changes.

This follow the process described in details in:

https://github.com/laminas/technical-steering-committee/blob/main/meetings/minutes/2021-08-02-TSC-Minutes.md#remove-laminaslaminas-zendframework-bridge-dependency-from-our-packages
